### PR TITLE
Bug in function name

### DIFF
--- a/home-made-32bits-adder.py
+++ b/home-made-32bits-adder.py
@@ -22,7 +22,7 @@
 
 import sys
 
-def adder32(A, B):
+def full_adder32(A, B):
     """
     ALU 1bit:
     A B Cin | Cout S


### PR DESCRIPTION
Hello. There is simple bug with function naming:

```
C:\Users\egyp7\github\Overcl0ck's Stuff\stuffz-master>python home-made-32b
-adder.py
Traceback (most recent call last):
  File "home-made-32bits-adder.py", line 156, in <module>
    sys.exit(main(len(sys.argv), sys.argv))
  File "home-made-32bits-adder.py", line 151, in main
    print full_adder32(1337,1338)
NameError: global name 'full_adder32' is not defined
```

1 line patch here:

```
import sys

-def adder32(A, B):
+def full_adder32(A, B):
     """
     ALU 1bit:
     A B Cin | Cout S
```
